### PR TITLE
Fix navigation anchors from legal pages

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -8,9 +8,9 @@ import { getI18n } from '../../i18n';
 const t = getI18n(Astro.currentLocale);
 
 const navItems = [
-  { href: '#projects', label: t('nav.projects') },
-  { href: '#services', label: t('nav.services') },
-  { href: '#about', label: t('nav.about') }
+  { href: '/#projects', label: t('nav.projects') },
+  { href: '/#services', label: t('nav.services') },
+  { href: '/#about', label: t('nav.about') }
 ];
 ---
 
@@ -43,7 +43,7 @@ const navItems = [
 
       <div class="hidden md:flex items-center gap-4 relative z-10">
         <ChristmasToggle />
-        <Button href="#contact" variant="primary" size="sm">
+        <Button href="/#contact" variant="primary" size="sm">
           {t('nav.contact')}
         </Button>
       </div>
@@ -99,7 +99,7 @@ const navItems = [
           ))
         }
         <hr class="border-surface-200 my-2" />
-        <Button href="#contact" variant="primary" size="sm" class="mobile-nav-link">
+        <Button href="/#contact" variant="primary" size="sm" class="mobile-nav-link">
           {t('nav.contact')}
         </Button>
       </nav>


### PR DESCRIPTION
## Summary
Fixes navigation anchor links to properly redirect from legal pages to the home page.

## Changes
- Updated navigation items to use absolute anchor paths (`/#projects` instead of `#projects`)
- Applied to all navigation items: Projects, Services, About, Contact
- Works for both desktop and mobile navigation

## Testing
- [x] Tested navigation from home page - smooth scrolling works
- [x] Tested navigation from /privacy, /terms, /cookies - redirects to home + scrolls
- [x] Tested mobile navigation menu
- [x] Verified build succeeds with no errors

## Closes
Closes #1